### PR TITLE
make the port configurable

### DIFF
--- a/src/mysql_slowlogd.c
+++ b/src/mysql_slowlogd.c
@@ -152,7 +152,7 @@ static struct tailed_file * open_tailed_file(const char *filename) {
 
     tf = malloc(sizeof(struct tailed_file));
     if (!tf) goto bail;
-    memset(tf, 0, sizeof(tf));
+    memset(tf, 0, sizeof(*tf));
 
     tf->name = strdup(filename);
     if (!tf->name) goto bail;


### PR DESCRIPTION
In certain environments it's desirable to make the slowlogd port configurable. This PR contains the a patch to introduce that small feature.

Also, there appears to be a memset deref bug that is required to successfully compile mysql_slowlogd.